### PR TITLE
Subject: Add GitHub profile links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Knowledge Representation 
 ## Made by Bit Bandits
 ### Members:
-1. Naveenkumar D
+1. Naveenkumar D - [GitHub Profile](https://github.com/19Naveen)
 2. Mithun Raaj S
-3. Siranjeevi K
+3. Siranjeevi K - [GitHub Profile](https://github.com/SiranjeeviK)
 4. Pathmesh G
 5. Ponnarasu A


### PR DESCRIPTION
Added GitHub profile links for team members in the README for improved visibility and accessibility.